### PR TITLE
[propeller] expose ability to call propeller kit init to external lib…

### DIFF
--- a/dist/js/propeller.js
+++ b/dist/js/propeller.js
@@ -15,7 +15,7 @@ var commons = function () {
 	function commons() {}
 	commons.attachParentSelector = function (parentSelector, defaultSelector) {
 		var customSelector = defaultSelector;
-		if (parentSelector !== '' && parentSelector.length > 0) {
+		if (parentSelector && parentSelector !== '' && parentSelector.length > 0) {
 			if (parentSelector === defaultSelector) {
 				customSelector = defaultSelector;
 			} else if ($(parentSelector).hasClass(defaultSelector)) {
@@ -95,6 +95,10 @@ var observeDOM = (function () {
 })();
 
 $(document).ready(function () {
+  $.propellerkit();
+});
+
+$.propellerkit = function() {
 	observeDOM(document.querySelector('body'), function (mutations) {
 		
 		processMutation(0);
@@ -171,7 +175,7 @@ $(document).ready(function () {
 			return false;
 		}
 	});
-});
+};
 
 
 /**


### PR DESCRIPTION
Adding ability to expose the propellerkit init method calls so that SPA type web apps can initialize propellerkit externally. For example, aurelia framework document.ready() is 'too late' given the lifecycle of page loads so we can instead use aurelia's page lifecycle to hook this in immediately.